### PR TITLE
Rename transaction response paratemer to qr_as_base64

### DIFF
--- a/tests/onepay/test_transaction.py
+++ b/tests/onepay/test_transaction.py
@@ -66,7 +66,7 @@ class TransactionTestCase(unittest.TestCase):
         self.assertIsNotNone(response.ott)
         self.assertIsNotNone(response.signature)
         self.assertIsNotNone(response.external_unique_number)
-        self.assertIsNotNone(response.qr_code_as_base64)
+        self.assertIsNotNone(response.qr_as_base64)
 
     def test_create_transaction_given_options(self):
         onepay.api_key = None
@@ -79,7 +79,7 @@ class TransactionTestCase(unittest.TestCase):
         self.assertIsNotNone(response.ott)
         self.assertIsNotNone(response.signature)
         self.assertIsNotNone(response.external_unique_number)
-        self.assertIsNotNone(response.qr_code_as_base64)
+        self.assertIsNotNone(response.qr_as_base64)
 
     def test_commit_transaction_global_options(self):
 

--- a/transbank/onepay/schema.py
+++ b/transbank/onepay/schema.py
@@ -27,7 +27,7 @@ class TransactionCreateResponseSchema(Schema):
     signature = fields.Str()
     external_unique_number = fields.Str(load_from="externalUniqueNumber", dump_to="externalUniqueNumber")
     issued_at = fields.Int(load_from="issuedAt", dump_to="issuedAt")
-    qr_code_as_base64 = fields.Str(load_from="qrCodeAsBase64", dump_to="qrCodeAsBase64")
+    qr_as_base64 = fields.Str(load_from="qrCodeAsBase64", dump_to="qrCodeAsBase64")
 
 class TransactionCommitRequestSchema(Schema):
     occ = fields.Str()

--- a/transbank/onepay/transaction.py
+++ b/transbank/onepay/transaction.py
@@ -43,13 +43,13 @@ class TransactionCreateRequest(Signable):
 class TransactionCreateResponse(Signable):
     signable_attributes = ['occ', 'external_unique_number', 'issued_at']
 
-    def __init__(self, occ, ott, signature, external_unique_number, issued_at, qr_code_as_base64):
+    def __init__(self, occ, ott, signature, external_unique_number, issued_at, qr_as_base64):
         self.occ = occ
         self.ott = ott
         self.signature = signature
         self.external_unique_number = external_unique_number
         self.issued_at = issued_at
-        self.qr_code_as_base64 = qr_code_as_base64
+        self.qr_as_base64 = qr_as_base64
 
 class TransactionCommitRequest(Signable):
 


### PR DESCRIPTION
Rename transaction response paratemer to qr_as_base64, to have consistency with the other sdks