### PR TITLE
Define TransactionCommitError

### DIFF
--- a/tests/onepay/test_error.py
+++ b/tests/onepay/test_error.py
@@ -1,17 +1,21 @@
 import unittest
 
 from transbank import onepay
-from transbank.onepay.error import TransactionCreateError, TransbankError, SignError
+from transbank.onepay.error import TransactionCreateError, TransactionCommitError, TransbankError, SignError
 
 class ErrorTestCase(unittest.TestCase):
 
     def test_errors(self):
         transaction_create_error = TransactionCreateError("Transaction Error", 100)
+        transaction_commit_error = TransactionCommitError("Transaction Commit Error", 150)
         transbank_error = TransbankError("Transbank Error", 200 )
         sign_error = SignError("Sign Error", 300)
 
         self.assertEqual(transaction_create_error.message, "Transaction Error")
         self.assertEqual(transaction_create_error.code, 100)
+
+        self.assertEqual(transaction_commit_error.message, "Transaction Commit Error")
+        self.assertEqual(transaction_commit_error.code, 150)
 
         self.assertEqual(transbank_error.message, "Transbank Error")
         self.assertEqual(transbank_error.code, 200)

--- a/tests/onepay/test_transaction.py
+++ b/tests/onepay/test_transaction.py
@@ -9,7 +9,7 @@ from transbank import onepay
 from transbank.onepay import Options
 from transbank.onepay.transaction import Transaction, Channel, TransactionCreateRequest
 from transbank.onepay.cart import ShoppingCart, Item
-from transbank.onepay.error import TransactionCreateError, SignError
+from transbank.onepay.error import TransactionCreateError, TransactionCommitError, SignError
 
 class TransactionTestCase(unittest.TestCase):
 
@@ -57,6 +57,13 @@ class TransactionTestCase(unittest.TestCase):
 
             with self.assertRaisesRegex(TransactionCreateError, "ERROR : ERROR"):
                 Transaction.create(self.get_valid_cart())
+
+    def test_raise_error_response_commit_transaction(self):
+        with requests_mock.Mocker() as m:
+            m.register_uri("POST", re.compile("/gettransactionnumber"), text="{\"response_code\": \"ERROR\", \"description\": \"ERROR\"}")
+
+            with self.assertRaisesRegex(TransactionCommitError, "ERROR : ERROR"):
+                Transaction.commit("occ", "external_unique_number")
 
     def test_create_transaction_global_options(self):
         response = Transaction.create(self.get_valid_cart())

--- a/transbank/onepay/error.py
+++ b/transbank/onepay/error.py
@@ -10,6 +10,11 @@ class TransactionCreateError(TransbankError):
         self.message = message
         self.code = code
 
+class TransactionCommitError(TransbankError):
+    def __init__(self, message = "Transaction could not be commited. Please verify given parameters", code = 0):
+        self.message = message
+        self.code = code
+
 class RefundCreateError(TransbankError):
     def __init__(self, message = "Refund could not be executed. Please verify given parameters", code = 0):
         self.message = message

--- a/transbank/onepay/transaction.py
+++ b/transbank/onepay/transaction.py
@@ -6,7 +6,7 @@ import requests
 from transbank.onepay.schema import ItemSchema, TransactionCreateRequestSchema, TransactionCreateResponseSchema, SendTransactionResponseSchema, TransactionCommitRequestSchema, SendCommitResponseSchema
 
 from transbank.onepay.cart import ShoppingCart
-from transbank.onepay.error import TransactionCreateError, SignError
+from transbank.onepay.error import TransactionCreateError, SignError, TransactionCommitError
 from transbank.onepay import Options, Signable
 
 from transbank import onepay
@@ -136,11 +136,11 @@ class Transaction(object):
         transaction_response = SendCommitResponseSchema().loads(data_response).data
 
         if transaction_response['response_code'] != "OK":
-            raise TransactionCreateError("%s : %s" % (transaction_response['response_code'], transaction_response['description']))
+            raise TransactionCommitError("%s : %s" % (transaction_response['response_code'], transaction_response['description']))
 
         result = TransactionCommitResponse(**transaction_response['result'])
 
         if not result.is_valid_signature((options or onepay).shared_secret, result.signature):
-            raise TransactionCreateError("The response signature is not valid.", -1)
+            raise TransactionCommitError("The response signature is not valid.", -1)
 
         return result


### PR DESCRIPTION
Define TransactionCommitError, to raise it when a transaction commit fails.