### PR TITLE
Fix validation in Transaction.create

### DIFF
--- a/tests/onepay/test_transaction.py
+++ b/tests/onepay/test_transaction.py
@@ -23,6 +23,8 @@ class TransactionTestCase(unittest.TestCase):
         onepay.integration_type = onepay.IntegrationType.MOCK
         onepay.api_key = self.api_key_mock
         onepay.shared_secret = self.shared_secret_mock
+        onepay.callback_url = None
+        onepay.app_scheme = None
 
     def test_get_signable_elements(self):
         request = TransactionCreateRequest(1, 1000, 1, 1, None, "http://localhost/callback")
@@ -39,9 +41,6 @@ class TransactionTestCase(unittest.TestCase):
         self.assertEqual(options.shared_secret, "shared_secret")
 
     def test_validate_create(self):
-        onepay.callback_url = None
-        onepay.app_scheme = None
-
         with self.assertRaisesRegex(Exception, "Shopping cart must not be null or empty"):
             Transaction.create(None)
 

--- a/tests/onepay/test_transaction.py
+++ b/tests/onepay/test_transaction.py
@@ -39,6 +39,9 @@ class TransactionTestCase(unittest.TestCase):
         self.assertEqual(options.shared_secret, "shared_secret")
 
     def test_validate_create(self):
+        onepay.callback_url = None
+        onepay.app_scheme = None
+
         with self.assertRaisesRegex(Exception, "Shopping cart must not be null or empty"):
             Transaction.create(None)
 

--- a/transbank/onepay/transaction.py
+++ b/transbank/onepay/transaction.py
@@ -90,10 +90,10 @@ class Transaction(object):
     @classmethod
     def create(cls, shopping_cart: ShoppingCart, channel = Channel.WEB, external_unique_number = None, options = None):
 
-        if (channel != None and channel == Channel.APP and onepay.app_scheme):
+        if (channel != None and channel == Channel.APP and not onepay.app_scheme):
             raise TransactionCreateError("You need to set an app_scheme if you want to use the APP channel")
 
-        if (channel != None and channel == Channel.MOBILE and onepay.callback_url):
+        if (channel != None and channel == Channel.MOBILE and not onepay.callback_url):
             raise TransactionCreateError("You need to set valid callback if you want to use the MOBILE channel")
 
         if not hasattr(shopping_cart, 'items') or (hasattr(shopping_cart, 'items') and not shopping_cart.items):


### PR DESCRIPTION
Fix validation in Transaction.create, to determinate the existence of callback or app_scheme.