### PR TITLE
Prepare release v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Todos los cambios notables a este proyecto serán docuemntados en este archivo.
 El formato está basado en [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 y este proyecto adhiere a [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2018-11-07
+### Fixed
+- En Onepay, se corrige error que impedía crear una transacción desde iOS.
+
+### Security
+- Actualización de dependencia a una versión libre de vulnerabilidades.
+
 ## [1.0.0] - 2018-10-23
 ### Added
 - Primera versión del SDK de Transbank, que contiene solamente las funcionalidades para implementar Onepay.

--- a/transbank/__version__.py
+++ b/transbank/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (1, 0, 0)
+VERSION = (1, 0, 1)
 
 __version__ = '.'.join(map(str, VERSION))


### PR DESCRIPTION
See full diff in: https://github.com/TransbankDevelopers/transbank-sdk-python/compare/v1.0.0...chore/prepare-release-v1.0.1