### PR TITLE
Bug/transaction options default values

### DIFF
--- a/tests/onepay/test_onepay.py
+++ b/tests/onepay/test_onepay.py
@@ -8,11 +8,15 @@ class OnepayTestCase(unittest.TestCase):
         onepay.shared_secret = "shared_secret"
         onepay.callback_url = "callback_url"
         onepay.app_scheme = "app_scheme"
+        onepay.commerce_logo_url = "commerce_logo_url"
+        onepay.qr_width_height = "qr_width_height"
 
         self.assertEqual(onepay.api_key, "api_key")
         self.assertEqual(onepay.shared_secret, "shared_secret")
         self.assertEqual(onepay.callback_url, "callback_url")
         self.assertEqual(onepay.app_scheme, "app_scheme")
+        self.assertEqual(onepay.commerce_logo_url, "commerce_logo_url")
+        self.assertEqual(onepay.qr_width_height, "qr_width_height")
 
     def test_integration_types(self):
         self.assertIsNotNone(onepay.IntegrationType.LIVE)

--- a/tests/onepay/test_transaction.py
+++ b/tests/onepay/test_transaction.py
@@ -3,6 +3,7 @@ import unittest.mock
 
 import requests_mock
 import re
+import json
 
 from transbank import onepay
 
@@ -10,6 +11,7 @@ from transbank.onepay import Options
 from transbank.onepay.transaction import Transaction, Channel, TransactionCreateRequest
 from transbank.onepay.cart import ShoppingCart, Item
 from transbank.onepay.error import TransactionCreateError, TransactionCommitError, SignError
+from transbank.onepay.schema import TransactionCreateRequestSchema
 
 class TransactionTestCase(unittest.TestCase):
 
@@ -89,6 +91,20 @@ class TransactionTestCase(unittest.TestCase):
         self.assertIsNotNone(response.signature)
         self.assertIsNotNone(response.external_unique_number)
         self.assertIsNotNone(response.qr_code_as_base64)
+
+    def test_create_transaction_skip_none_params(self):
+        external_unique_number_req = 123
+        options = Options()
+        shopping_cart = self.get_valid_cart()
+
+        req = TransactionCreateRequest(external_unique_number_req,
+              shopping_cart.total, shopping_cart.item_quantity,
+              5473782781, shopping_cart.items,
+              onepay.callback_url, Channel.WEB.value , onepay.app_scheme, options)
+        request_string = TransactionCreateRequestSchema().dumps(req).data
+        request_json = json.loads(request_string)
+        self.assertFalse('commerceLogoUrl' in request_json)
+        self.assertFalse('widthHeight' in request_json)
 
     def test_commit_transaction_global_options(self):
 

--- a/transbank/onepay/__init__.py
+++ b/transbank/onepay/__init__.py
@@ -37,11 +37,25 @@ qr_width_height = None
 commerce_logo_url = None
 
 class Options(object):
-    def __init__(self, api_key: str, shared_secret: str, qr_width_height=qr_width_height, commerce_logo_url=commerce_logo_url):
+    def __init__(self, api_key: str=api_key, shared_secret: str=shared_secret,
+                 commerce_logo_url: str=commerce_logo_url, qr_width_height=qr_width_height):
         self.api_key = api_key
         self.shared_secret = shared_secret
-        self.qr_width_height = qr_width_height
         self.commerce_logo_url = commerce_logo_url
+        self.qr_width_height = qr_width_height
+
+    @classmethod
+    def build(cls, options: dict):
+        if options is None:
+            return Options(api_key, shared_secret)
+        else:
+            options = Options(
+                options.api_key or api_key,
+                options.shared_secret or shared_secret,
+                options.commerce_logo_url or commerce_logo_url,
+                options.qr_width_height or qr_width_height
+            )
+            return options
 
 
 class Signable(object):

--- a/transbank/onepay/transaction.py
+++ b/transbank/onepay/transaction.py
@@ -32,11 +32,13 @@ class TransactionCreateRequest(Signable):
         self.channel = channel
         self.app_scheme = app_scheme
         self.app_key = onepay.integration_type.value.app_key
-        self.api_key = (options or onepay).api_key
         self.generate_ott_qr_code = True
         self.options = options or onepay
-        self.qr_width_height = self.options.qr_width_height
-        self.commerce_logo_url = self.options.commerce_logo_url
+        self.api_key = self.options.api_key
+        if self.options.commerce_logo_url is not None:
+            self.commerce_logo_url = self.options.commerce_logo_url
+        if self.options.qr_width_height is not None:
+            self.qr_width_height = self.options.qr_width_height
 
     @property
     def signature(self):
@@ -105,6 +107,7 @@ class Transaction(object):
         api_base = onepay.integration_type.value.api_base
 
         external_unique_number_req = external_unique_number or int(datetime.now().timestamp() * 1000)
+        options = Options.build(options)
 
         req = TransactionCreateRequest(external_unique_number_req,
               shopping_cart.total, shopping_cart.item_quantity,


### PR DESCRIPTION
Options in Python SDK were behaving different than in other SDKs. 

For example you couldn't just pass the qr width height or commerce logo url on their own. Options constructor forced you to pass also the api key and the shared secret.
