### PR TITLE
Prepare release 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ y este proyecto adhiere a [Semantic Versioning](http://semver.org/spec/v2.0.0.ht
 
 ## [1.1.0] - 2019-04-04
 ### Added
-- Se agregaron los parámetros `qr_width_height` y `commerce_logo_url` a Options. Ahora puedes configurar estos parámetros globalmente o por transacción.
+- Se agregaron los parámetros `qr_width_height` y `commerce_logo_url` a Options, para especificar el tamaño del QR generado para la transacción, y especificar la ubicación del logo de comercio para ser mostrado en la aplicación móvil de Onepay. Puedes configurar estos parámetros globalmente o por transacción.
 
 ## [1.0.1] - 2018-11-07
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Todos los cambios notables a este proyecto serán docuemntados en este archivo.
 El formato está basado en [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 y este proyecto adhiere a [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2019-04-04
+### Added
+- Se agregaron los parámetros `qr_width_height` y `commerce_logo_url` a Options. Ahora puedes configurar estos parámetros globalmente o por transacción.
+
 ## [1.0.1] - 2018-11-07
 ### Fixed
 - En Onepay, se corrige error que impedía crear una transacción desde iOS.

--- a/transbank/__version__.py
+++ b/transbank/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (1, 0, 1)
+VERSION = (1, 1, 0)
 
 __version__ = '.'.join(map(str, VERSION))


### PR DESCRIPTION
Added qr width height and commerce logo url support

Full diff: [v1.0.1...prepare-release-1.1.0](https://github.com/TransbankDevelopers/transbank-sdk-python/compare/v1.0.1...prepare-release-1.1.0)