### PR TITLE
Add docker, docker-compose & makefiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ __pycache__/
 # C extensions
 *.so
 
+.DS_Store
+
 # Distribution / packaging
 .Python
 build/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.7.4-stretch
+RUN apt-get update && apt-get install -y python3-pip
+RUN pip install pipenv
+RUN mkdir -p /sdk
+WORKDIR /sdk
+COPY . /sdk

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+SHELL := /bin/bash
+
+all: build run
+
+run: build
+	docker-compose run --rm web
+
+build: .built .bundled
+
+.built: Dockerfile
+	docker-compose build
+	touch .built
+
+.bundled: Pipfile
+	docker-compose run web pipenv install
+	touch .bundled
+
+logs:
+	docker-compose logs
+
+clean:
+	docker-compose rm
+	rm .built
+	rm .bundled

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '2'
+services:
+  web: &web
+    tty: true
+    stdin_open: true
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: bash
+    volumes:
+    - .:/sdk
+    volumes_from:
+      - python_cache
+    ports:
+    - "8000:8000"
+
+  python_cache:
+    image:  python:3.7.4-stretch
+    volumes:
+    - /usr/local/lib/python3.7/site-packages


### PR DESCRIPTION
Add docker, to simplify the development process for the SDK (so you don't have to add dependencies, python, pip and others by yourself to be able to develop with the appropriate editor/IDE hinting, completion, etc).

Also it can be helpful if tests are implemented later, so you don't have to install everything just to run some tests