### PR TITLE
Prepare release 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Todos los cambios notables a este proyecto serán docuemntados en este archivo.
 El formato está basado en [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 y este proyecto adhiere a [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+## [1.2.1] - 2020-10-08
+### Fixed
+- Se arregla error en la respuesta de OneClick Mall [PR #69](https://github.com/TransbankDevelopers/transbank-sdk-python/pull/69) de [@hsandovaltides](https://github.com/hsandovaltides)
+- Ahora se lanza excepción si se pasa un valor que no sea integer en el campo amount. [PR 68](ttps://github.com/TransbankDevelopers/transbank-sdk-python/pull/68)
+
 ## [1.2.0] - 2019-12-26
 ### Added
 - Se agrega soporte para Oneclick Mall y Transacción Completa en sus versiones REST.

--- a/transbank/__version__.py
+++ b/transbank/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (1, 2, 0)
+VERSION = (1, 2, 1)
 
 __version__ = '.'.join(map(str, VERSION))


### PR DESCRIPTION
See full diff in: [v1.1.0...chore/prepare-release-1.2.1](https://github.com/TransbankDevelopers/transbank-sdk-python/compare/v1.1.0...chore/prepare-release-1.2.1)