### PR TITLE
Fix duplication on Mall transactions

### DIFF
--- a/transbank/webpay/webpay_plus/request/__init__.py
+++ b/transbank/webpay/webpay_plus/request/__init__.py
@@ -48,11 +48,12 @@ class MallDetails(object):
             and self.buy_order == other.buy_order
 
 
-class MallTransactionCreateDetails(object):
+class MallTransactionCreateDetails:
     __details = []
 
     def __init__(self, amount: float, commerce_code: str, buy_order: str):
-        self.add(amount, commerce_code, buy_order)
+        mall_details = MallDetails(amount, commerce_code, buy_order)
+        self.__details = [mall_details]
 
     def add(self, amount: float, commerce_code: str, buy_order: str) -> "MallTransactionCreateDetails":
         mall_details = MallDetails(amount, commerce_code, buy_order)

--- a/transbank/webpay/webpay_plus/request/__init__.py
+++ b/transbank/webpay/webpay_plus/request/__init__.py
@@ -48,12 +48,15 @@ class MallDetails(object):
             and self.buy_order == other.buy_order
 
 
-class MallTransactionCreateDetails:
+class MallTransactionCreateDetails(object):
     __details = []
 
     def __init__(self, amount: float, commerce_code: str, buy_order: str):
-        mall_details = MallDetails(amount, commerce_code, buy_order)
-        self.__details = [mall_details]
+        self.clean()
+        self.add(amount, commerce_code, buy_order)
+
+    def clean(self):
+        self.__details = []
 
     def add(self, amount: float, commerce_code: str, buy_order: str) -> "MallTransactionCreateDetails":
         mall_details = MallDetails(amount, commerce_code, buy_order)


### PR DESCRIPTION
Every time a user refreshed the view previous to the payment (or
similar), the base amount of the transaction was doubled.

This was fixed by changing the __init__ method of the
MallTransactionCreateDetails class.

The class attribute "__details" was left there in case a user uses the
"add" method without instantiating the class.