### PR TITLE
Prepare Release 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ Todos los cambios notables a este proyecto serán docuemntados en este archivo.
 El formato está basado en [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 y este proyecto adhiere a [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2021-10-28
+### Fixed
+- Actualización de versión mínima requerida de dependencia Marshmallow.
+
+### Security
+- Actualización de dependencia urllib3 a una versión libre de vulnerabilidades.
+
+
 ## [2.0.0] - 2021-10-19
 ### Added
 Los métodos apuntan a la versión 1.2 del API de Transbank, por lo que ahora las redirecciones de vuelta en el

--- a/transbank/__version__.py
+++ b/transbank/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (2, 0, 0)
+VERSION = (2, 0, 1)
 
 __version__ = '.'.join(map(str, VERSION))


### PR DESCRIPTION
Full diff [2.0.0...chore/prepare-release-2.0.1](https://github.com/TransbankDevelopers/transbank-sdk-python/compare/2.0.0...chore/prepare-release-2.0.1) 