### PR TITLE
fix has text validation

### DIFF
--- a/transbank/common/validation_util.py
+++ b/transbank/common/validation_util.py
@@ -4,7 +4,7 @@ class ValidationUtil(object):
 
     @staticmethod
     def has_text(value: str, value_name: str):
-        if not value and not value.strip():
+        if not value or not value.strip():
             raise TransbankError("'{}' can't be null or white space".format(value_name))
 
     @staticmethod


### PR DESCRIPTION
I updated the `and` validation in line 7 `if not value or not value.strip():` to use a `or` instead.

If `value` is None, then `value.strip()` will raise an `AttributeError` -> `'NoneType' object has no attribute 'strip'`.

The `or` validation will immediately raise the `TransbankError` instead evaluating `value.strip()` when value is `None`.