### PR TITLE
chore: remove sonarcloud token from travis.yml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ jobs:
     addons:
       sonarcloud:
         organization: transbankdevelopers
-        token:
-          secure: NJwpmGuauUP+OLnpbN9nmDqmSXdo/84q8/CdL9UFsFSjVabd8rqE8Q6e8lrpZHV10kf2Gft13ACCuNnJq9aJcmS9d4A/ir4zZ7Eux1qJ5QvDkhTh5IFyGCAEh/gYtRLkmaPXwl5ueSHwyx+go5Ka/ilFkF/S3jVqdXKA1qfe+rTIoDeWeK4pP6ggebzGXZE+WQ11D3kolvbHEVhhIxFuayxw9nszxEuVda0D47bN6Z3+ykwNRGLKJTQLiwT8D5kTsbaYc4mHnItOV+T51WVmdXEOM10LkzBOabQarnVlyeRti5LCCSNY13vCoi6kbpR+61zi27s4iE09UXAt5HaoLa52OzoNRDyJp3efLcHpPym9oIlMNuS+2iAjlT/zLNnNZuCunoZ687XKMI+sgnt16Ydn2UrcinY/Yy/DBYIdDoNrnsxjuE258ySkW6+CKpYVQ5R/rL5iA/XgPgnbiKFZnkxaTRE4k8NcRyxkfG9zYn3boB2ZQ5+tiOmjJcctJ+KKUheX9ekI5DV8P9Gq2QaIElKIyJ2yBj73rjjLOv6YVy1OFexIV34Es02vJjMHpUGG2ctwzVb9bNThZrcbhMERq3ZTjf+ohJouSMDR4KRHCSL/VSxVAkm1hepPNLMHN//veEf5YAiYt8dFBnQs1fv+c6wa2Z7HlUa4UhEVcf9NbWY=
     script:
     - pipenv run citests
     - sonar-scanner -Dsonar.projectKey=transbank-sdk-python -Dsonar.projectName="Transbank


### PR DESCRIPTION
This PR remove sonar_token from travis.yml to solve build issue on Travis - CI.

- [x] Add new token variable on sonarcloud
Sonarcloud:
<img width="845" alt="image" src="https://github.com/TransbankDevelopers/transbank-sdk-python/assets/16402208/668e0dcd-c1b7-4fa5-a44d-5dc0ced42912">

travis web:
<img width="1379" alt="image" src="https://github.com/TransbankDevelopers/transbank-sdk-python/assets/16402208/6091b44a-8a7b-43c0-a7a8-d885982b1dfe">

- [x] Remove sonar_token from travis.yml 

travis.yml:
<img width="452" alt="image" src="https://github.com/TransbankDevelopers/transbank-sdk-python/assets/16402208/49940d7f-1bc3-4179-b95a-23c17b7d9c30">

