### PR TITLE
fix: return response code to avoid code breaking

### DIFF
--- a/transbank/common/request_service.py
+++ b/transbank/common/request_service.py
@@ -34,7 +34,7 @@ class RequestService(object):
     @classmethod
     def process_response(cls, response: any):
         if not response.text:
-            return 
+            return response.status_code
         dict_response = json.loads(response.text)
         if response.status_code not in (200, 299):
             if "error_message" in dict_response:


### PR DESCRIPTION
This PR returns the response code so we avoid the code breaking when trying to delete a inscription on `Oneclick`.

Evidence:
https://github.com/TransbankDevelopers/transbank-sdk-python/assets/16856300/dc55df16-0cbd-4067-8a8b-37408855e2f6

