### PR TITLE
fix: delete and refund fix

### DIFF
--- a/transbank/common/api_constants.py
+++ b/transbank/common/api_constants.py
@@ -14,3 +14,4 @@ class ApiConstants(object):
     COMMERCE_CODE_LENGTH = 12
     TOKEN_LENGTH = 64
     EMAIL_LENGTH = 100
+    HTTP_STATUS_DELETE_OK = 204

--- a/transbank/common/request_service.py
+++ b/transbank/common/request_service.py
@@ -34,7 +34,7 @@ class RequestService(object):
     @classmethod
     def process_response(cls, response: any):
         if not response.text:
-            return 
+            return response.status_code
         dict_response = json.loads(response.text)
         if response.status_code not in (200, 299):
             if "error_message" in dict_response:

--- a/transbank/webpay/oneclick/mall_inscription.py
+++ b/transbank/webpay/oneclick/mall_inscription.py
@@ -49,7 +49,12 @@ class MallInscription(WebpayTransaction):
         try:
             endpoint = MallInscription.DELETE_ENDPOINT
             request = MallInscriptionDeleteRequest(username, tbk_user)
-            RequestService.delete(endpoint, MallInscriptionDeleteRequestSchema().dumps(request), self.options)
+            response = RequestService.delete(endpoint, MallInscriptionDeleteRequestSchema().dumps(request), self.options)
+            if response == 204:                
+                return True
+            else:                
+                return False
+                
         except TransbankError as e:
             raise InscriptionDeleteError(e.message, e.code)
 

--- a/transbank/webpay/oneclick/mall_inscription.py
+++ b/transbank/webpay/oneclick/mall_inscription.py
@@ -50,10 +50,7 @@ class MallInscription(WebpayTransaction):
             endpoint = MallInscription.DELETE_ENDPOINT
             request = MallInscriptionDeleteRequest(username, tbk_user)
             response = RequestService.delete(endpoint, MallInscriptionDeleteRequestSchema().dumps(request), self.options)
-            if response == ApiConstants.HTTP_STATUS_DELETE_OK:                
-                return True
-            else:                
-                return False
+            return response == ApiConstants.HTTP_STATUS_DELETE_OK
                 
         except TransbankError as e:
             raise InscriptionDeleteError(e.message, e.code)

--- a/transbank/webpay/oneclick/mall_inscription.py
+++ b/transbank/webpay/oneclick/mall_inscription.py
@@ -50,7 +50,7 @@ class MallInscription(WebpayTransaction):
             endpoint = MallInscription.DELETE_ENDPOINT
             request = MallInscriptionDeleteRequest(username, tbk_user)
             response = RequestService.delete(endpoint, MallInscriptionDeleteRequestSchema().dumps(request), self.options)
-            if response == 204:                
+            if response == ApiConstants.HTTP_STATUS_DELETE_OK:                
                 return True
             else:                
                 return False

--- a/transbank/webpay/transaccion_completa/transaction.py
+++ b/transbank/webpay/transaccion_completa/transaction.py
@@ -66,7 +66,7 @@ class Transaction(WebpayTransaction):
         try:
             endpoint = Transaction.REFUND_ENDPOINT.format(token)
             request = TransactionRefundRequest(amount)
-            return RequestService.post(endpoint, TransactionRefundRequestSchema().dumps(request).data, self.options)
+            return RequestService.post(endpoint, TransactionRefundRequestSchema().dumps(request), self.options)
         except TransbankError as e:
             raise TransactionRefundError(e.message, e.code)
 


### PR DESCRIPTION
This PR adds the following changes:
- Returns a `boolean` in the method `delete` for Oneclick Mall Inscription.
- Fix the method `refund` for Full Transaction.

## Evidence
### Full Transaction Refund
Before:

https://github.com/TransbankDevelopers/transbank-sdk-python/assets/16856300/2009eae3-374c-41cf-8136-195de64ca2b8

After:

https://github.com/TransbankDevelopers/transbank-sdk-python/assets/16856300/d7a842ac-5f44-4229-8a07-59be9f05536a



### Oneclick Mall Delete Inscription
https://github.com/TransbankDevelopers/transbank-sdk-python/assets/16856300/dc55df16-0cbd-4067-8a8b-37408855e2f6

